### PR TITLE
Support a plus character in a variable value

### DIFF
--- a/microdot-core/src/graph.rs
+++ b/microdot-core/src/graph.rs
@@ -270,7 +270,7 @@ impl Variable {
     }
 
     pub fn variable_rx() -> Regex {
-        Regex::new("\\$([A-Za-z][A-Za-z0-9_-]*)=([A-Za-z0-9+_-]+)").expect("not a regex")
+        Regex::new("\\$([A-Za-z][A-Za-z0-9_-]*)=(\\S+)").expect("not a regex")
     }
 
     pub fn parse(input: &str) -> Option<Self> {

--- a/microdot-core/src/graph.rs
+++ b/microdot-core/src/graph.rs
@@ -270,7 +270,7 @@ impl Variable {
     }
 
     pub fn variable_rx() -> Regex {
-        Regex::new("\\$([A-Za-z][A-Za-z0-9_-]*)=([A-Za-z0-9_-]+)").expect("not a regex")
+        Regex::new("\\$([A-Za-z][A-Za-z0-9_-]*)=([A-Za-z0-9+_-]+)").expect("not a regex")
     }
 
     pub fn parse(input: &str) -> Option<Self> {
@@ -781,5 +781,16 @@ mod time_tests {
 
         let time = Time::Day(1) + Time::Hour(1) + Time::Minute(15);
         assert_eq!(format!("{}", time), "1 day 1 hour 15 minutes");
+    }
+}
+
+#[cfg(test)]
+mod variable_tests {
+    use super::*;
+
+    #[test]
+    fn it_can_parse_a_plus_in_a_variable_string() {
+        let variable = Variable::parse("$foo=x+1");
+        assert_eq!(variable.unwrap().value, VariableValue::string("x+1"));
     }
 }

--- a/microdot-core/src/labels.rs
+++ b/microdot-core/src/labels.rs
@@ -179,6 +179,14 @@ mod tests {
     }
 
     #[test]
+    fn it_matches_multiple_variables() {
+        let (variables, _) = extract_variables("$var1=variable1 $var2=variable2");
+
+        assert_eq!(variables.get("var1"), Some(&Variable::new("var1", VariableValue::string("variable1"))));
+        assert_eq!(variables.get("var2"), Some(&Variable::new("var2", VariableValue::string("variable2"))));
+    }
+
+    #[test]
     fn it_parses_node_label_with_no_markup() {
         let actual = NodeInfo::parse(&Label("no hashtags".to_string()));
         let expected = NodeInfo {


### PR DESCRIPTION
In order to be able to apply a label such as `dday+4`. A minus sign for `dday-4` is already supported